### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,19 +6,19 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-MX1508       KEYWORD1
-DecayMode    KEYWORD1
-NumOfPWMPins KEYWORD1
+MX1508	KEYWORD1
+DecayMode	KEYWORD1
+NumOfPWMPins	KEYWORD1
 
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-motorGo	      KEYWORD2
+motorGo	KEYWORD2
 setResolution	KEYWORD2
-getPWM	      KEYWORD2
-stopMotor	    KEYWORD2
+getPWM	KEYWORD2
+stopMotor	KEYWORD2
 
 
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords